### PR TITLE
Pin natural to v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "language-tags": "^1.0.5",
     "linter-spell-word-list": "^0.4.2",
     "lodash": "^4.17.4",
-    "natural": "^0.5.0",
+    "natural": "0.5.0",
     "os-locale": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`natural@0.5.1` brings in a requirement on Python, which isn't something that fits within the "runs within Atom" concept, so for now this is getting pinned to v0.5.0.

Fixes #50.