### PR TITLE
Remove console log

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -51,9 +51,6 @@ const Main = {
         this.createLanguageListView))
 
     require('atom-package-deps').install('linter-spell')
-      .then(() => {
-        console.log('All dependencies installed, good to go')
-      })
   },
 
   deactivate () {

--- a/lib/main.js
+++ b/lib/main.js
@@ -51,6 +51,9 @@ const Main = {
         this.createLanguageListView))
 
     require('atom-package-deps').install('linter-spell')
+      .catch(e => {
+        console.error(e)
+      })
   },
 
   deactivate () {


### PR DESCRIPTION
That log statement adds noise to the console to report something going _right_. If logging is required for debugging, it should be togglable in settings and / or report when something goes wrong. 

Presumably, if `atom-package-deps` did have an issue that prevented the `then` clause from activating, it would throw an error and this will catch it.